### PR TITLE
Add vector env var support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,54 @@ Rust decouple is a long term project that aims to mimic the functionality of the
 Due to the nature of the Rust language, the library will be implemented in a different way, but the goal is to provide a similar functionality. So far, the library is in a very early stage of development and is not ready for use.
 
 The benefits of the rust version is that the cast is automatically done by the library, so you don't have to worry about it.
+
+## Usage
+
+### Basic usage
+
+The most basic usage of the library is to get a variable from the environment, if it is not found, it will return an error.
+
+```rs
+use rust_decouple::macros::config;
+
+...
+let my_string: String = config!("VAR_NAME");
+```
+
+You can also specify a default value if the variable is not found
+
+```rs
+use rust_decouple::macros::config;
+
+...
+let my_string = config!("VAR_NAME", "default_value");
+```
+
+In this case, the variable type will be inferred from the default value.
+If the default value is ambiguous, you can specify the type like this:
+
+```rs
+use rust_decouple::macros::config;
+
+...
+// The type is annotated by the user
+let my_string: u8 = config!("VAR_NAME", 8);
+
+// The type is inferred from the default value
+let my_string = config!("VAR_NAME", 8u8);
+```
+
+Notice that this usage of default doesn't cover the case where the variable is found but is empty or invalid.
+
+### Vectorized environment variables
+
+You can also get a vector of values from the environment, the values should be separated by a comma without spaces in between.
+
+```rs
+use rust_decouple::macros::config_vec;
+
+...
+let my_vec: Vec<String> = config_vec!("VAR_NAME");
+let my_vec = config_vec!("VAR_NAME", vec!["1", "2"]);
+let my_vec: Vec<u8> = config_vec!("VAR_NAME", vec![1, 2]);
+```

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -5,7 +5,7 @@
 /// let variable_with_default: i32 = config!("NOT_DEFINED_I32_VAR", 0);
 /// // Automatically inferred that `variable_with_default_and_type_inferred` is u8 due to the default value
 /// let variable_with_default_and_type_inferred = config!("VAR", 0u8);
-/// ``````
+/// ```
 #[macro_export]
 macro_rules! config {
     ($var_name:expr, $default_value:expr) => {
@@ -13,5 +13,23 @@ macro_rules! config {
     };
     ($var_name:expr) => {
         rust_decouple::core::Environment::from($var_name, None)
+    };
+}
+
+/// Macro for Vector environment parser
+/// ## Usage
+/// /// ```rs
+/// let variable: Vec<u8> = config!("VEC_U8_VAR");
+/// let variable_with_default: Vec<i32> = config!("NOT_DEFINED_I32_VAR", vec![]);
+/// // Automatically inferred that `variable_with_default_and_type_inferred` is u8 due to the default value
+/// let variable_with_default_and_type_inferred = config!("VAR", vec![0u8]);
+/// ```
+#[macro_export]
+macro_rules! config_vec {
+    ($var_name:expr, $default_value:expr) => {
+        rust_decouple::core::VecEnvironment::from($var_name, Some($default_value))
+    };
+    ($var_name:expr) => {
+        rust_decouple::core::VecEnvironment::from($var_name, None);
     };
 }


### PR DESCRIPTION
# Problem

The current version doesn't support a vectorized env var, this is, parse an env variable as a vec of T is not accepted.

# Solution

Implement new struct for handling Vec<T> env vars and add the macro config_vec to support an easy usage of it

# Future work

When rust implement FromStr for Vec<T>, a lot of redundant code will be deleted