### PR TITLE
Derive trait Decouple

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
 name = "rust_decouple_derive"
 version = "0.1.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,48 @@
 version = 3
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "rust-decouple"
 version = "0.1.2"
+
+[[package]]
+name = "rust-decouple-derive"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,9 +23,12 @@ dependencies = [
 [[package]]
 name = "rust-decouple"
 version = "0.1.2"
+dependencies = [
+ "rust_decouple_derive",
+]
 
 [[package]]
-name = "rust-decouple-derive"
+name = "rust_decouple_derive"
 version = "0.1.0"
 dependencies = [
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "rust-decouple"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "rust_decouple_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,8 @@ edition = "2021"
 rust-version = "1.80.0"
 
 [dependencies]
-rust_decouple_derive = { path = "rust_decouple_derive" }
+rust_decouple_derive = { path = "rust_decouple_derive", optional = true }
+
+[features]
+default = []
+derive = ["dep:rust_decouple_derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["rust_decouple_derive"]
+
 [package]
 name = "rust-decouple"
 description = "A simple library to ease the process of parsing environment variables"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = ["rust_decouple_derive"]
 
 [package]
@@ -14,3 +15,4 @@ edition = "2021"
 rust-version = "1.80.0"
 
 [dependencies]
+rust_decouple_derive = { path = "rust_decouple_derive" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 keywords = ["config"]
 authors = ["joyanedel <iamjoyanedel@gmail.com>"]
 repository = "https://github.com/joyanedel/rust-decouple"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.80.0"
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ The most basic usage of the library is to get a variable from the environment, i
 ```rs
 use rust_decouple::macros::config;
 
-...
 let my_string: String = config!("VAR_NAME");
 ```
 
@@ -24,7 +23,6 @@ You can also specify a default value if the variable is not found
 ```rs
 use rust_decouple::macros::config;
 
-...
 let my_string = config!("VAR_NAME", "default_value");
 ```
 
@@ -34,25 +32,52 @@ If the default value is ambiguous, you can specify the type like this:
 ```rs
 use rust_decouple::macros::config;
 
-...
 // The type is annotated by the user
 let my_string: u8 = config!("VAR_NAME", 8);
 
 // The type is inferred from the default value
-let my_string = config!("VAR_NAME", 8u8);
+let my_u8 = config!("VAR_NAME", 8u8);
 ```
 
 Notice that this usage of default doesn't cover the case where the variable is found but is empty or invalid.
 
-### Vectorized environment variables
+#### Vectorized environment variables
 
 You can also get a vector of values from the environment, the values should be separated by a comma without spaces in between.
 
 ```rs
 use rust_decouple::macros::config_vec;
 
-...
 let my_vec: Vec<String> = config_vec!("VAR_NAME");
 let my_vec = config_vec!("VAR_NAME", vec!["1", "2"]);
 let my_vec: Vec<u8> = config_vec!("VAR_NAME", vec![1, 2]);
+```
+
+### Derived trait
+
+You can also derive the `Decouple` trait for your structs, this will allow you to get the values from the environment in a more structured way as the example below:
+
+```rs
+use rust_decouple::Decouple;
+
+#[derive(Decouple)]
+struct Test {
+    var_1: u8,
+    var_2: Vec<i32>,
+    var_3: Vec<String>,
+}
+
+fn main() {
+    let env_vars = Test::parse();
+    println!("{}", env_vars.var_1);
+    println!("{:?}", env_vars.var_2);
+    println!("{:?}", env_vars.var_3);
+}
+```
+
+To use it, you need to enable the feature `derive` in your `Cargo.toml` file:
+
+```toml
+[dependencies]
+rust_decouple = { version = "0.1", features = ["derive"] }
 ```

--- a/rust_decouple_derive/Cargo.toml
+++ b/rust_decouple_derive/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+proc-macro2 = "1.0.86"
 quote = "1.0.36"
 syn = "2.0.72"
 

--- a/rust_decouple_derive/Cargo.toml
+++ b/rust_decouple_derive/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rust-decouple-derive"
+name = "rust_decouple_derive"
 version = "0.1.0"
 edition = "2021"
 

--- a/rust_decouple_derive/Cargo.toml
+++ b/rust_decouple_derive/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust-decouple-derive"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+quote = "1.0.36"
+syn = "2.0.72"
+
+[lib]
+proc-macro = true

--- a/rust_decouple_derive/src/lib.rs
+++ b/rust_decouple_derive/src/lib.rs
@@ -1,9 +1,8 @@
-use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput};
+use syn::{parse_macro_input, DeriveInput, Ident, Type};
 
 #[proc_macro_derive(EnvVarParser)]
-pub fn derive_env_var_parser(input: TokenStream) -> TokenStream {
+pub fn derive_env_var_parser(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;
 
@@ -13,27 +12,27 @@ pub fn derive_env_var_parser(input: TokenStream) -> TokenStream {
                 .fields
                 .iter()
                 .filter_map(|f| {
-                    let f = f.clone();
-                    if f.ident.is_some() {
-                        Some((f.ident.unwrap(), f.ty))
+                    let ident = f.clone().ident;
+                    let ty = f.ty.clone();
+                    let ty_is_vec = f.ty.clone();
+                    if ident.as_ref().is_some() {
+                        Some((ident.unwrap(), ty, is_vec(ty_is_vec)))
                     } else {
                         None
                     }
                 })
                 .collect();
-
-            let field_names: Vec<_> = fields.iter().map(|(a, _)| a).collect();
-            let field_names_uppercase: Vec<_> = field_names
-                .iter()
-                .map(|f| f.to_string().to_uppercase())
-                .collect();
-            let field_types: Vec<_> = fields.iter().map(|(_, b)| b).collect();
+            let non_vec_fields: Vec<_> = fields.iter().filter(|(_, _, v)| !v).collect();
+            let non_vec_fields = gen_fields(non_vec_fields);
+            let vec_fields: Vec<_> = fields.iter().filter(|(_, _, v)| *v).collect();
+            let vec_fields = gen_fields(vec_fields);
 
             quote! {
                 impl EnvVarParser for #name {
                     fn parse() -> Self {
                         Self {
-                            #(#field_names: rust_decouple::core::Environment::from::<#field_types>(#field_names_uppercase, None),)*
+                            #non_vec_fields
+                            #vec_fields
                         }
                     }
                 }
@@ -43,4 +42,34 @@ pub fn derive_env_var_parser(input: TokenStream) -> TokenStream {
     };
 
     expanded.into()
+}
+
+/// this function must be improved
+fn is_vec(v: Type) -> bool {
+    let v = quote!(#v).to_string();
+    v.starts_with("Vec")
+}
+
+fn gen_fields(fields: Vec<&(Ident, Type, bool)>) -> proc_macro2::TokenStream {
+    if fields.len() == 0 {
+        return quote! {};
+    }
+
+    let field_names: Vec<_> = fields.iter().map(|(f, _, _)| f).collect();
+    let field_names_uppercase: Vec<_> = fields
+        .iter()
+        .map(|(f, _, _)| f.to_string().to_uppercase())
+        .collect();
+    let field_types: Vec<_> = fields.iter().map(|(_, t, _)| t).collect();
+    let is_vec = fields.iter().next().unwrap().2;
+
+    if is_vec {
+        quote! {
+            #(#field_names: rust_decouple::core::VecEnvironment::from(#field_names_uppercase, None) as #field_types,)*
+        }
+    } else {
+        quote! {
+            #(#field_names: rust_decouple::core::Environment::from::<#field_types>(#field_names_uppercase, None),)*
+        }
+    }
 }

--- a/rust_decouple_derive/src/lib.rs
+++ b/rust_decouple_derive/src/lib.rs
@@ -1,0 +1,43 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput, Type};
+
+#[proc_macro_derive(EnvVarParser)]
+pub fn derive_env_var_parser(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+    let name_str = name.to_string();
+
+    let expanded = match input.data {
+        syn::Data::Struct(ref data_struct) => {
+            let fields: Vec<_> = data_struct
+                .fields
+                .iter()
+                .filter_map(|f| {
+                    let f = f.clone();
+                    if f.ident.is_some() {
+                        Some((f.ident.unwrap(), f.ty))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            let field_names: Vec<_> = fields.iter().map(|(a, _)| a).collect();
+            let field_types: Vec<_> = fields.iter().map(|(_, b)| b).collect();
+
+            quote! {
+                impl EnvVarParser for #name {
+                    fn parse() -> Self {
+                        Self {
+                            #(#field_names: <#field_types>::default(),)*
+                        }
+                    }
+                }
+            }
+        }
+        _ => panic!("#[derive(EnvVarParser)] is only defined for structs"),
+    };
+
+    expanded.into()
+}

--- a/rust_decouple_derive/src/lib.rs
+++ b/rust_decouple_derive/src/lib.rs
@@ -1,7 +1,7 @@
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput, Ident, Type};
 
-#[proc_macro_derive(EnvVarParser)]
+#[proc_macro_derive(Decouple)]
 pub fn derive_env_var_parser(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;
@@ -28,7 +28,7 @@ pub fn derive_env_var_parser(input: proc_macro::TokenStream) -> proc_macro::Toke
             let vec_fields = gen_fields(vec_fields);
 
             quote! {
-                impl EnvVarParser for #name {
+                impl Decouple for #name {
                     fn parse() -> Self {
                         Self {
                             #non_vec_fields
@@ -38,7 +38,7 @@ pub fn derive_env_var_parser(input: proc_macro::TokenStream) -> proc_macro::Toke
                 }
             }
         }
-        _ => panic!("#[derive(EnvVarParser)] is only defined for structs"),
+        _ => panic!("#[derive(Decouple)] is only defined for structs"),
     };
 
     expanded.into()

--- a/src/core.rs
+++ b/src/core.rs
@@ -9,7 +9,7 @@ impl Environment {
     pub fn from<T: FromStr>(var_name: &str, default: Option<T>) -> T {
         let value = env::var(var_name);
         if value.is_err() && default.is_none() {
-            panic!("Couldn't find `{var_name}`");
+            panic!("Couldn't find environment variable `{var_name}`");
         } else if let Some(default_value) = default {
             return default_value;
         }
@@ -71,7 +71,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Couldn't find `NOT_SET_VALUE_2`")]
+    #[should_panic(expected = "Couldn't find environment variable `NOT_SET_VALUE_2`")]
     fn parse_not_set_env_var_with_no_default_value_panics() {
         env::remove_var("NOT_SET_VALUE_2");
         Environment::from::<u8>("NOT_SET_VALUE_2", None);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,13 @@
-pub use rust_decouple_derive;
+// #[cfg(feature = "derive")]
+// pub use rust_decouple_derive;
+
 pub mod core;
 pub mod macros;
+mod traits;
+
+#[cfg(feature = "derive")]
+extern crate rust_decouple_derive;
+#[cfg(feature = "derive")]
+pub use rust_decouple_derive::EnvVarParser;
+#[cfg(feature = "derive")]
+pub use traits::EnvVarParser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
+pub use rust_decouple_derive;
 pub mod core;
 pub mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-// #[cfg(feature = "derive")]
-// pub use rust_decouple_derive;
-
 pub mod core;
 pub mod macros;
 mod traits;
@@ -8,6 +5,6 @@ mod traits;
 #[cfg(feature = "derive")]
 extern crate rust_decouple_derive;
 #[cfg(feature = "derive")]
-pub use rust_decouple_derive::EnvVarParser;
+pub use rust_decouple_derive::Decouple;
 #[cfg(feature = "derive")]
-pub use traits::EnvVarParser;
+pub use traits::Decouple;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -18,7 +18,7 @@ macro_rules! config {
 
 /// Macro for Vector environment parser
 /// ## Usage
-/// /// ```rs
+/// ```rs
 /// let variable: Vec<u8> = config!("VEC_U8_VAR");
 /// let variable_with_default: Vec<i32> = config!("NOT_DEFINED_I32_VAR", vec![]);
 /// // Automatically inferred that `variable_with_default_and_type_inferred` is u8 due to the default value

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -4,7 +4,7 @@
 /// let variable: u8 = config!("U8_VAR");
 /// let variable_with_default: i32 = config!("NOT_DEFINED_I32_VAR", 0);
 /// // Automatically inferred that `variable_with_default_and_type_inferred` is u8 due to the default value
-/// let variable_with_default_and_type_inferred = config!("VAR", 0u8);
+/// let variable_with_default_and_inferred_type = config!("VAR", 0u8);
 /// ```
 #[macro_export]
 macro_rules! config {
@@ -22,7 +22,7 @@ macro_rules! config {
 /// let variable: Vec<u8> = config!("VEC_U8_VAR");
 /// let variable_with_default: Vec<i32> = config!("NOT_DEFINED_I32_VAR", vec![]);
 /// // Automatically inferred that `variable_with_default_and_type_inferred` is u8 due to the default value
-/// let variable_with_default_and_type_inferred = config!("VAR", vec![0u8]);
+/// let variable_with_default_and_inferred_type = config!("VAR", vec![0u8]);
 /// ```
 #[macro_export]
 macro_rules! config_vec {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,3 +1,3 @@
-pub trait EnvVarParser {
+pub trait Decouple {
     fn parse() -> Self;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,0 +1,3 @@
+pub trait EnvVarParser {
+    fn parse() -> Self;
+}


### PR DESCRIPTION
# Problem

Users need a easy way to access their environment variables without write too verbose code

# Solution

Implement a derived trait with proc macros to facilitate the parsing of env vars